### PR TITLE
Add methods processing dynamic link when the app is opened for the first time on iOS

### DIFF
--- a/src/ios/AppDelegate+FirebaseDynamicLinksPlugin.m
+++ b/src/ios/AppDelegate+FirebaseDynamicLinksPlugin.m
@@ -62,6 +62,39 @@
                  continueUserActivity:userActivity
                    restorationHandler:restorationHandler];
 }
+
+
+
+- (BOOL)application:(UIApplication *)app
+            openURL:(NSURL *)url
+            options:(NSDictionary<NSString *, id> *)options {
+    return [self application:app
+                     openURL:url
+           sourceApplication:options[UIApplicationOpenURLOptionsSourceApplicationKey]
+                  annotation:options[UIApplicationOpenURLOptionsAnnotationKey]];
+}
+
+- (BOOL)application:(UIApplication *)application
+            openURL:(NSURL *)url
+  sourceApplication:(NSString *)sourceApplication
+         annotation:(id)annotation {
+    FIRDynamicLink *dynamicLink = [[FIRDynamicLinks dynamicLinks] dynamicLinkFromCustomSchemeURL:url];
+    
+    FirebaseDynamicLinksPlugin* dl = [self.viewController getCommandInstance:@"FirebaseDynamicLinks"];
+    if (dynamicLink) {
+        if (dynamicLink.url) {
+            [dl postDynamicLink:dynamicLink];
+        } else {
+            // Dynamic link has empty deep link. This situation will happens if
+            // Firebase Dynamic Links iOS SDK tried to retrieve pending dynamic link,
+            // but pending link is not available for this device/App combination.
+            // At this point you may display default onboarding view.
+        }
+        return YES;
+    }
+    return NO;
+}
+
 // [END continueuseractivity]
 
 @end

--- a/src/ios/AppDelegate+FirebaseDynamicLinksPlugin.m
+++ b/src/ios/AppDelegate+FirebaseDynamicLinksPlugin.m
@@ -37,7 +37,12 @@
 // [START continueuseractivity]
 - (BOOL)identity_application:(UIApplication *)application
         continueUserActivity:(NSUserActivity *)userActivity
-          restorationHandler:(void (^)(NSArray *))restorationHandler {
+          restorationHandler:
+#if defined(__IPHONE_12_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_12_0)
+(nonnull void (^)(NSArray<id<UIUserActivityRestoring>> *_Nullable))restorationHandler {
+#else
+    (nonnull void (^)(NSArray *_Nullable))restorationHandler {
+#endif  // __IPHONE_12_0
     FirebaseDynamicLinksPlugin* dl = [self.viewController getCommandInstance:@"FirebaseDynamicLinks"];
 
     BOOL handled = [[FIRDynamicLinks dynamicLinks]


### PR DESCRIPTION
PR adding methods needed for the app to process dynamic link on iOS, when the app is opened for the first time after installation, as mentioned in the Firebase docs:
[https://firebase.google.com/docs/dynamic-links/ios/receive#open-dynamic-links-in-your-app](https://firebase.google.com/docs/dynamic-links/ios/receive#open-dynamic-links-in-your-app)