### PR TITLE
Fix UIWebview deprecation from Firebase podspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,3 +130,8 @@ Any create method supports all options below to customize a returned dynamic lin
 [twitter-url]: https://twitter.com/chemerisuk
 [twitter-follow]: https://img.shields.io/twitter/follow/chemerisuk.svg?style=social&label=Follow%20me
 [donate-url]: https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=USD4VHG7CF6FN&source=url
+
+#### Changelog 21 Dec 2020
+
+- Pinning pod spec to 7 causes issues with Google sign-in pods so we've now kept it a bare minimum above the commit when UIWebview was removed i.e. [Pinned at 6.8.0](https://github.com/firebase/firebase-ios-sdk/commit/89a276928c847befeae4c58aad0cd15900630058)
+- Since analytics is not used the pod dependancy has been removed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cordova-plugin-firebase-dynamiclinks2",
-  "version": "4.0.8",
+  "version": "4.0.9",
   "description": "Cordova plugin for Firebase Dynamic Links",
   "cordova": {
     "id": "cordova-plugin-firebase-dynamiclinks2",

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,7 +1,7 @@
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
 xmlns:android="http://schemas.android.com/apk/res/android"
            id="cordova-plugin-firebase-dynamiclinks2"
-      version="4.0.8">
+      version="4.0.9">
 
     <name>FirebaseDynamicLinksPlugin</name>
     <description>Cordova plugin for Firebase Dynamic Links</description>
@@ -106,8 +106,7 @@ xmlns:android="http://schemas.android.com/apk/res/android"
                 <source url="https://cdn.cocoapods.org/"/>
             </config>
             <pods>
-                <pod name="Firebase/Analytics" spec="~> 6.25.0" />
-                <pod name="Firebase/Analytics" spec="~> 6.25.0" />
+                <pod name="Firebase/DynamicLinks" spec="6.8.0" />
             </pods>
         </podspec>
     </platform>


### PR DESCRIPTION
This PR fixes following items
- UIWebview deprecation warning which was introduced due to conditional UIWebView code from older Firebase dynamic links pod
- Remove unused Firebase analytics pod

If the project makes use of Google sign-in then the podspec for Firebase Dynamic links must be kept below 7.0 as it causes issue with resolution of GTMsessionfetcher which is part of a branched dependancy from Google utils